### PR TITLE
Fix capability lang key, add missing lang strings, remove hardcoded UI text

### DIFF
--- a/index.php
+++ b/index.php
@@ -72,8 +72,8 @@ class local_grpcalendarimport_form extends moodleform {
         $mform->addElement(
             'advcheckbox',
             'skipduplicates',
-            'Skip duplicate events',
-            'Skip if an event with the same name, course and timestart already exists',
+            get_string('skipduplicates', 'local_grpcalendarimport'),
+            get_string('skipduplicates_desc', 'local_grpcalendarimport'),
             [],
             [0, 1]
         );
@@ -97,7 +97,7 @@ if ($form->is_cancelled()) {
     $tmpfile = $form->save_temp_file('csvfile');
 
     if (!$tmpfile) {
-        \core\notification::error('Could not read uploaded file.');
+        \core\notification::error(get_string('upload_error', 'local_grpcalendarimport'));
     } else {
         $rows      = local_grpcalendarimport_parse_csv($tmpfile);
         $skipdupes = !empty($data->skipduplicates);
@@ -110,7 +110,7 @@ if ($form->is_cancelled()) {
             $counts[$result['status']]++;
             $rownum++;
         }
-        @unlink($tmpfile);
+        unlink($tmpfile);
 
         \core\notification::success(
             "Import complete — Created: {$counts['ok']}, Skipped: {$counts['skip']}, Errors: {$counts['error']}."
@@ -128,7 +128,11 @@ if (!empty($results)) {
     echo $OUTPUT->heading(get_string('results_heading', 'local_grpcalendarimport'), 3);
 
     $table             = new html_table();
-    $table->head       = ['Row', 'Event Name / Message', 'Status'];
+    $table->head       = [
+        get_string('row', 'local_grpcalendarimport'),
+        get_string('event_message', 'local_grpcalendarimport'),
+        get_string('status', 'local_grpcalendarimport'),
+    ];
     $table->attributes = ['class' => 'generaltable'];
 
     foreach ($results as $r) {

--- a/lang/en/local_grpcalendarimport.php
+++ b/lang/en/local_grpcalendarimport.php
@@ -25,15 +25,20 @@
 defined('MOODLE_INTERNAL') || die();
 
 // Strings in alphabetical order as required by Moodle coding style.
-$string['calendarimport:manage'] = 'Import calendar events';
-$string['import_button']         = 'Import Events';
-$string['import_heading']        = 'Import Group Calendar Events';
-$string['pluginname']            = 'Calendar Group Event Importer';
-$string['pluginname_desc']       = 'Import group calendar events from a CSV file.';
-$string['privacy:metadata']      = 'This plugin does not directly store any personal data. Calendar events are stored in the core calendar system.';
-$string['results_heading']       = 'Import Results';
-$string['row']                   = 'Row';
-$string['status_error']          = 'Error';
-$string['status_ok']             = 'Created';
-$string['status_skip']           = 'Skipped (already exists)';
-$string['upload_csv']            = 'Upload CSV file';
+$string['event_message']              = 'Event Name / Message';
+$string['grpcalendarimport:manage']   = 'Import group calendar events';
+$string['import_button']              = 'Import Events';
+$string['import_heading']             = 'Import Group Calendar Events';
+$string['pluginname']                 = 'Calendar Group Event Importer';
+$string['pluginname_desc']            = 'Import group calendar events from a CSV file.';
+$string['privacy:metadata']           = 'This plugin does not directly store any personal data. Calendar events are stored in the core calendar system.';
+$string['results_heading']            = 'Import Results';
+$string['row']                        = 'Row';
+$string['skipduplicates']             = 'Skip duplicate events';
+$string['skipduplicates_desc']        = 'Skip if an event with the same name, course and timestart already exists';
+$string['status']                     = 'Status';
+$string['status_error']               = 'Error';
+$string['status_ok']                  = 'Created';
+$string['status_skip']                = 'Skipped (already exists)';
+$string['upload_csv']                 = 'Upload CSV file';
+$string['upload_error']               = 'Could not read uploaded file.';

--- a/session-notes.md
+++ b/session-notes.md
@@ -28,14 +28,11 @@ Checks: `phplint`, `phpmd`, `codechecker`, `phpdoc`, `validate`, `savepoints`, `
 Key fix: PostgreSQL Docker auto-creates a database named after `POSTGRES_USER`, so the workflow now uses the `postgres` superuser for pgsql and `root` for mariadb to avoid a "database already exists" conflict on install.
 
 ## Current state
-- Branch `claude/upload-moodle-plugin-e6oTw` is **5 commits ahead of main**
-- CI is passing codechecker (fixed inline comment full-stop warning in `version.php`)
-- A PR was attempted but failed — needs to be raised manually or retried
+- All code is on **main** — PRs #7 and #9 merged
+- CI passing on all 3 matrix jobs (PHP 8.1/8.2/8.3 × pgsql/mariadb)
+- PHPUnit test suite in `tests/locallib_test.php` covers parse_csv and create_event
 
 ## Next steps
-- [ ] Merge branch into main via PR
-- [ ] Confirm full CI green (all 3 matrix jobs pass)
 - [ ] Test plugin install on a real Moodle 4.5 instance
 - [ ] Upload to the Moodle Plugins Directory if required
-- [ ] Consider adding PHPUnit tests for `local_grpcalendarimport_parse_csv()` and `local_grpcalendarimport_create_event()`
 - [ ] Consider adding Behat tests for the upload form

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_grpcalendarimport';
-$plugin->version   = 2026041710;
+$plugin->version   = 2026042201;
 $plugin->requires  = 2024100700; // Moodle 4.5.
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = '1.0.1';


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Bug fix**: Rename capability lang string key from `calendarimport:manage` to `grpcalendarimport:manage` — the old key was never resolved by Moodle's permissions UI, leaving the capability with no human-readable label
- **Missing lang strings**: Add `event_message`, `skipduplicates`, `skipduplicates_desc`, `status`, `upload_error` so all UI text is translatable
- **Hardcoded strings removed**: Replace inline English literals in `index.php` (form checkbox label/description, error notification, table headers) with `get_string()` calls
- **Minor cleanup**: Remove `@` error suppression from `unlink()` call; update stale `session-notes.md`

## Test plan

- [ ] Confirm CI passes on all 3 matrix jobs (PHP 8.1/8.2/8.3)
- [ ] Verify the `local/grpcalendarimport:manage` capability shows its label correctly in Site administration → Users → Permissions
- [ ] Upload a CSV and confirm the results table renders column headings correctly

https://claude.ai/code/session_01AvPPcqfzW2azKf4Kk1Z9dk
EOF
)