### PR TITLE
Fix moodle codechecker violations in instructions panel

### DIFF
--- a/download.php
+++ b/download.php
@@ -27,9 +27,9 @@ require_login();
 require_capability('local/grpcalendarimport:manage', context_system::instance());
 
 // Timestamps used in sample rows (all in 2026, future relative to plugin release).
-// 1746086400 = 2026-05-01 08:00 UTC
-// 1746172800 = 2026-05-02 08:00 UTC
-// 1748736000 = 2026-06-01 08:00 UTC
+// 1746086400 = 2026-05-01 08:00 UTC.
+// 1746172800 = 2026-05-02 08:00 UTC.
+// 1748736000 = 2026-06-01 08:00 UTC.
 $content = "name,courseid,groupid,timestart,timeduration,description,location,eventtype,visible\r\n"
          . "Team Meeting,2,5,1746086400,3600,Weekly sync,Room 101,group,1\r\n"
          . "Practice Session,2,6,1746172800,5400,Pre-game warmup,Field B,group,1\r\n"

--- a/download.php
+++ b/download.php
@@ -1,0 +1,45 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Serve the sample CSV file for download.
+ *
+ * @package   local_grpcalendarimport
+ * @copyright 2026 SCCA
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../config.php');
+require_login();
+require_capability('local/grpcalendarimport:manage', context_system::instance());
+
+// Timestamps used in sample rows (all in 2026, future relative to plugin release).
+// 1746086400 = 2026-05-01 08:00 UTC
+// 1746172800 = 2026-05-02 08:00 UTC
+// 1748736000 = 2026-06-01 08:00 UTC
+$content = "name,courseid,groupid,timestart,timeduration,description,location,eventtype,visible\r\n"
+         . "Team Meeting,2,5,1746086400,3600,Weekly sync,Room 101,group,1\r\n"
+         . "Practice Session,2,6,1746172800,5400,Pre-game warmup,Field B,group,1\r\n"
+         . "Championship Race,3,7,1748736000,7200,Regional finals,Track A,group,1\r\n";
+
+header('Content-Type: text/csv; charset=utf-8');
+header('Content-Disposition: attachment; filename="grp_calendar_sample.csv"');
+header('Content-Length: ' . strlen($content));
+header('Cache-Control: no-cache, no-store, must-revalidate');
+header('Pragma: no-cache');
+header('Expires: 0');
+echo $content;
+die();

--- a/index.php
+++ b/index.php
@@ -132,10 +132,10 @@ $reqtable->head = [
     'Description',
 ];
 $reqtable->data = [
-    [html_writer::tag('code', 'name'),      'Event title'],
-    [html_writer::tag('code', 'courseid'),  'Moodle course ID — visible in the course URL '
+    [html_writer::tag('code', 'name'), 'Event title'],
+    [html_writer::tag('code', 'courseid'), 'Moodle course ID — visible in the course URL '
         . '(e.g. ' . html_writer::tag('code', '/course/view.php?id=2') . ')'],
-    [html_writer::tag('code', 'groupid'),   'Moodle group ID — must belong to the course '
+    [html_writer::tag('code', 'groupid'), 'Moodle group ID — must belong to the course '
         . '(find via Course &rsaquo; Participants &rsaquo; Groups)'],
     [html_writer::tag('code', 'timestart'), 'Event start as a Unix timestamp '
         . '(e.g. ' . html_writer::tag('code', '1746086400') . ' = 2026-05-01 08:00 UTC)'],
@@ -149,11 +149,11 @@ $rectable->head = [
     get_string('default_value', 'local_grpcalendarimport'),
 ];
 $rectable->data = [
-    [html_writer::tag('code', 'timeduration'), 'Duration in seconds',     '3600 (1 hour)'],
-    [html_writer::tag('code', 'eventtype'),    'Calendar event type',     '"group"'],
-    [html_writer::tag('code', 'description'),  'Event description text',  '(empty)'],
-    [html_writer::tag('code', 'location'),     'Location string',         '(empty)'],
-    [html_writer::tag('code', 'visible'),      '1 = visible, 0 = hidden', '1'],
+    [html_writer::tag('code', 'timeduration'), 'Duration in seconds', '3600 (1 hour)'],
+    [html_writer::tag('code', 'eventtype'), 'Calendar event type', '"group"'],
+    [html_writer::tag('code', 'description'), 'Event description text', '(empty)'],
+    [html_writer::tag('code', 'location'), 'Location string', '(empty)'],
+    [html_writer::tag('code', 'visible'), '1 = visible, 0 = hidden', '1'],
 ];
 
 $opttable = new html_table();
@@ -163,11 +163,11 @@ $opttable->head = [
     'Description',
 ];
 $opttable->data = [
-    [html_writer::tag('code', 'categoryid'),     'Category ID'],
-    [html_writer::tag('code', 'userid'),         'User ID to associate with the event'],
-    [html_writer::tag('code', 'timesort'),       'Sort timestamp (defaults to timestart)'],
-    [html_writer::tag('code', 'uuid'),           'Unique identifier for external sync'],
-    [html_writer::tag('code', 'priority'),       'Display priority'],
+    [html_writer::tag('code', 'categoryid'), 'Category ID'],
+    [html_writer::tag('code', 'userid'), 'User ID to associate with the event'],
+    [html_writer::tag('code', 'timesort'), 'Sort timestamp (defaults to timestart)'],
+    [html_writer::tag('code', 'uuid'), 'Unique identifier for external sync'],
+    [html_writer::tag('code', 'priority'), 'Display priority'],
     [html_writer::tag('code', 'subscriptionid'), 'Calendar subscription ID'],
 ];
 
@@ -179,26 +179,39 @@ $samplecsv = implode("\n", [
 ]);
 
 $panelbody = html_writer::tag('p', get_string('csv_format_intro', 'local_grpcalendarimport'));
-$panelbody .= html_writer::tag('h6',
+$panelbody .= html_writer::tag(
+    'h6',
     get_string('required_columns', 'local_grpcalendarimport'),
-    ['class' => 'fw-bold mt-3']);
+    ['class' => 'fw-bold mt-3']
+);
 $panelbody .= html_writer::table($reqtable);
-$panelbody .= html_writer::tag('h6',
+$panelbody .= html_writer::tag(
+    'h6',
     get_string('recommended_columns', 'local_grpcalendarimport'),
-    ['class' => 'fw-bold mt-3']);
+    ['class' => 'fw-bold mt-3']
+);
 $panelbody .= html_writer::table($rectable);
-$panelbody .= html_writer::tag('h6',
+$panelbody .= html_writer::tag(
+    'h6',
     get_string('optional_columns', 'local_grpcalendarimport'),
-    ['class' => 'fw-bold mt-3']);
+    ['class' => 'fw-bold mt-3']
+);
 $panelbody .= html_writer::table($opttable);
-$panelbody .= html_writer::tag('h6',
+$panelbody .= html_writer::tag(
+    'h6',
     get_string('sample_csv_heading', 'local_grpcalendarimport'),
-    ['class' => 'fw-bold mt-3']);
-$panelbody .= html_writer::tag('pre', htmlspecialchars($samplecsv),
-    ['class' => 'bg-light p-2 border rounded small']);
-$panelbody .= html_writer::link($sampleurl,
+    ['class' => 'fw-bold mt-3']
+);
+$panelbody .= html_writer::tag(
+    'pre',
+    htmlspecialchars($samplecsv),
+    ['class' => 'bg-light p-2 border rounded small']
+);
+$panelbody .= html_writer::link(
+    $sampleurl,
     get_string('download_sample', 'local_grpcalendarimport'),
-    ['class' => 'btn btn-sm btn-outline-secondary']);
+    ['class' => 'btn btn-sm btn-outline-secondary']
+);
 
 $togglebtn = html_writer::tag(
     'button',
@@ -214,8 +227,11 @@ $togglebtn = html_writer::tag(
 );
 $cardheader = html_writer::div($togglebtn, 'card-header');
 $collapseinner = html_writer::div($panelbody, 'card-body');
-$collapsediv = html_writer::tag('div', $collapseinner,
-    ['class' => 'collapse show', 'id' => 'grpcalinstructions']);
+$collapsediv = html_writer::tag(
+    'div',
+    $collapseinner,
+    ['class' => 'collapse show', 'id' => 'grpcalinstructions']
+);
 echo html_writer::div($cardheader . $collapsediv, 'card mb-4');
 
 $form->display();

--- a/index.php
+++ b/index.php
@@ -122,6 +122,102 @@ if ($form->is_cancelled()) {
 echo $OUTPUT->header();
 echo $OUTPUT->heading(get_string('import_heading', 'local_grpcalendarimport'));
 
+// Instructions panel (collapsed by default; expands on click).
+$sampleurl = new moodle_url('/local/grpcalendarimport/download.php');
+
+$reqtable = new html_table();
+$reqtable->attributes = ['class' => 'table table-sm table-bordered mb-3'];
+$reqtable->head = [
+    get_string('description_column', 'local_grpcalendarimport'),
+    'Description',
+];
+$reqtable->data = [
+    [html_writer::tag('code', 'name'),      'Event title'],
+    [html_writer::tag('code', 'courseid'),  'Moodle course ID — visible in the course URL '
+        . '(e.g. ' . html_writer::tag('code', '/course/view.php?id=2') . ')'],
+    [html_writer::tag('code', 'groupid'),   'Moodle group ID — must belong to the course '
+        . '(find via Course &rsaquo; Participants &rsaquo; Groups)'],
+    [html_writer::tag('code', 'timestart'), 'Event start as a Unix timestamp '
+        . '(e.g. ' . html_writer::tag('code', '1746086400') . ' = 2026-05-01 08:00 UTC)'],
+];
+
+$rectable = new html_table();
+$rectable->attributes = ['class' => 'table table-sm table-bordered mb-3'];
+$rectable->head = [
+    get_string('description_column', 'local_grpcalendarimport'),
+    'Description',
+    get_string('default_value', 'local_grpcalendarimport'),
+];
+$rectable->data = [
+    [html_writer::tag('code', 'timeduration'), 'Duration in seconds',     '3600 (1 hour)'],
+    [html_writer::tag('code', 'eventtype'),    'Calendar event type',     '"group"'],
+    [html_writer::tag('code', 'description'),  'Event description text',  '(empty)'],
+    [html_writer::tag('code', 'location'),     'Location string',         '(empty)'],
+    [html_writer::tag('code', 'visible'),      '1 = visible, 0 = hidden', '1'],
+];
+
+$opttable = new html_table();
+$opttable->attributes = ['class' => 'table table-sm table-bordered mb-3'];
+$opttable->head = [
+    get_string('description_column', 'local_grpcalendarimport'),
+    'Description',
+];
+$opttable->data = [
+    [html_writer::tag('code', 'categoryid'),     'Category ID'],
+    [html_writer::tag('code', 'userid'),         'User ID to associate with the event'],
+    [html_writer::tag('code', 'timesort'),       'Sort timestamp (defaults to timestart)'],
+    [html_writer::tag('code', 'uuid'),           'Unique identifier for external sync'],
+    [html_writer::tag('code', 'priority'),       'Display priority'],
+    [html_writer::tag('code', 'subscriptionid'), 'Calendar subscription ID'],
+];
+
+$samplecsv = implode("\n", [
+    'name,courseid,groupid,timestart,timeduration,description,location,eventtype,visible',
+    'Team Meeting,2,5,1746086400,3600,Weekly sync,Room 101,group,1',
+    'Practice Session,2,6,1746172800,5400,Pre-game warmup,Field B,group,1',
+    'Championship Race,3,7,1748736000,7200,Regional finals,Track A,group,1',
+]);
+
+$panelbody = html_writer::tag('p', get_string('csv_format_intro', 'local_grpcalendarimport'));
+$panelbody .= html_writer::tag('h6',
+    get_string('required_columns', 'local_grpcalendarimport'),
+    ['class' => 'fw-bold mt-3']);
+$panelbody .= html_writer::table($reqtable);
+$panelbody .= html_writer::tag('h6',
+    get_string('recommended_columns', 'local_grpcalendarimport'),
+    ['class' => 'fw-bold mt-3']);
+$panelbody .= html_writer::table($rectable);
+$panelbody .= html_writer::tag('h6',
+    get_string('optional_columns', 'local_grpcalendarimport'),
+    ['class' => 'fw-bold mt-3']);
+$panelbody .= html_writer::table($opttable);
+$panelbody .= html_writer::tag('h6',
+    get_string('sample_csv_heading', 'local_grpcalendarimport'),
+    ['class' => 'fw-bold mt-3']);
+$panelbody .= html_writer::tag('pre', htmlspecialchars($samplecsv),
+    ['class' => 'bg-light p-2 border rounded small']);
+$panelbody .= html_writer::link($sampleurl,
+    get_string('download_sample', 'local_grpcalendarimport'),
+    ['class' => 'btn btn-sm btn-outline-secondary']);
+
+$togglebtn = html_writer::tag(
+    'button',
+    get_string('instructions_heading', 'local_grpcalendarimport'),
+    [
+        'type'           => 'button',
+        'class'          => 'btn btn-link text-start w-100 p-0 text-decoration-none fw-semibold',
+        'data-bs-toggle' => 'collapse',
+        'data-bs-target' => '#grpcalinstructions',
+        'aria-expanded'  => 'true',
+        'aria-controls'  => 'grpcalinstructions',
+    ]
+);
+$cardheader = html_writer::div($togglebtn, 'card-header');
+$collapseinner = html_writer::div($panelbody, 'card-body');
+$collapsediv = html_writer::tag('div', $collapseinner,
+    ['class' => 'collapse show', 'id' => 'grpcalinstructions']);
+echo html_writer::div($cardheader . $collapsediv, 'card mb-4');
+
 $form->display();
 
 if (!empty($results)) {

--- a/lang/en/local_grpcalendarimport.php
+++ b/lang/en/local_grpcalendarimport.php
@@ -25,15 +25,24 @@
 defined('MOODLE_INTERNAL') || die();
 
 // Strings in alphabetical order as required by Moodle coding style.
+$string['csv_format_intro']           = 'Upload a comma- or tab-delimited file with a header row. Columns can be in any order. UTF-8 and UTF-8-BOM encodings are both accepted.';
+$string['default_value']              = 'Default';
+$string['description_column']         = 'Column';
+$string['download_sample']            = 'Download sample CSV';
 $string['event_message']              = 'Event Name / Message';
 $string['grpcalendarimport:manage']   = 'Import group calendar events';
 $string['import_button']              = 'Import Events';
 $string['import_heading']             = 'Import Group Calendar Events';
+$string['instructions_heading']       = 'Instructions';
+$string['optional_columns']           = 'Optional columns';
 $string['pluginname']                 = 'Calendar Group Event Importer';
 $string['pluginname_desc']            = 'Import group calendar events from a CSV file.';
 $string['privacy:metadata']           = 'This plugin does not directly store any personal data. Calendar events are stored in the core calendar system.';
+$string['recommended_columns']        = 'Recommended columns';
+$string['required_columns']           = 'Required columns';
 $string['results_heading']            = 'Import Results';
 $string['row']                        = 'Row';
+$string['sample_csv_heading']         = 'Example CSV';
 $string['skipduplicates']             = 'Skip duplicate events';
 $string['skipduplicates_desc']        = 'Skip if an event with the same name, course and timestart already exists';
 $string['status']                     = 'Status';

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_grpcalendarimport';
-$plugin->version   = 2026042201;
+$plugin->version   = 2026042301;
 $plugin->requires  = 2024100700; // Moodle 4.5.
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = '1.0.1';

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_grpcalendarimport';
-$plugin->version   = 2026042301;
+$plugin->version   = 2026042302;
 $plugin->requires  = 2024100700; // Moodle 4.5.
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = '1.0.1';


### PR DESCRIPTION
## Summary

Fixes the 39 phpcs errors and 1 warning reported by `moodle-plugin-ci codechecker --max-warnings 0` against the code introduced in #13 (instructions panel + sample CSV download).

This branch is based on main and includes all commits from #13, so it can either supersede that PR or be merged after it.

### Fixes

**`index.php` (39 errors)**
- Removed column-alignment whitespace after commas in `$reqtable->data`, `$rectable->data`, and `$opttable->data` array literals (`Universal.WhiteSpace.CommaSpacing.TooMuchSpaceAfter`).
- Reformatted multi-line `html_writer::tag(...)` / `html_writer::link(...)` calls to PSR-2 style: opening paren last on line, each arg on its own line indented one level, closing paren on its own line (`PSR2.Methods.FunctionCallSignature.*`).

**`download.php` (1 warning)**
- Ended the inline UTC timestamp comments with full stops (`moodle.Commenting.InlineComment.InvalidEndChar`).

## Test plan

- [ ] `moodle-plugin-ci codechecker ./plugin --max-warnings 0` passes with 0 errors / 0 warnings
- [ ] Instructions panel still renders correctly on the import page (tables, sample CSV block, download button)
- [ ] `download.php` still serves `grp_calendar_sample.csv` with the sample rows

https://claude.ai/code/session_013H5MAb5twdqaLnHVJRzwRw

---
_Generated by [Claude Code](https://claude.ai/code/session_013H5MAb5twdqaLnHVJRzwRw)_